### PR TITLE
JavaScript in Artikel 'Tutorial' ergänzt

### DIFF
--- a/docs/de/tutorial/updates.md
+++ b/docs/de/tutorial/updates.md
@@ -1,12 +1,34 @@
 ---
 title:       "Tutorial"
-lastChanged: "14.09.2018"
+lastChanged: "16.06.2019"
 ---
 
-# Durchführen von Updates
 
-?> ***Dies ist ein Platzhalter***.
+# Tutorials
+
+?> **Die ioBroker-Dokumentation wird derzeit erweitert** und ist noch unvollständig.
+   <br>Daher werden hier, neben den hier bisher veröffentlichten Tutorials, noch hilfreiche Links gelistet. Auch dies ist im Aufbau.
    <br><br>
-   Hilf mit bei ioBroker und erweitere diesen Artikel.    
-   Bitte beachte den [ioBroker Style Guide](community/styleguidedoc), 
-   damit die Änderungen einfacher übernommen werden können.
+   *Hilf mit bei ioBroker und erweitere die Artikel.*
+   *Bitte beachte dabei den [ioBroker Style Guide](community/styleguidedoc), 
+   damit die Änderungen einfacher übernommen werden können.*
+
+## JavaScript-Adapter
+ioBroker bietet mit dem standardmäßig installierten [JavaScript-Adapter (Engine)](https://github.com/ioBroker/ioBroker.javascript) die Möglichkeit, schnell eigene Skripte zu entwickeln und zu verwalten.
+Die Entwicklung kann dabei in JavaScript, Blockly, oder TypeScript erfolgen.
+Links:
+* [Allgemeine Erklärung JavaScript-Adapter](https://github.com/ioBroker/ioBroker.javascript/blob/master/docs/de/usage.md)
+
+* [JavaScript Befehlsreferenz für ioBroker](https://github.com/ioBroker/ioBroker.javascript/blob/master/docs/en/javascript.md) (in Englisch)
+
+* [Verwendung von Blockly](https://github.com/ioBroker/ioBroker.javascript/blob/master/docs/de/blockly.md)
+
+* [Einführung in die Programmierung mit JavaScript](https://www.iobroker.net/docu/index-43.htm?page_id=5385&lang=de) (**Achtung**: Link auf veraltete ioBroker-Dokumentation)
+
+* [javascript.info](https://javascript.info/) Hervorragendes Tutorial zu JavaScript (in Englisch)
+
+
+## Script-Beispiele
+
+Viele Script-Beispiele (JavaScript und Blockly) finden sich im ioBroker-Forum unter [Skripten / Logik](https://forum.iobroker.net/category/6/skripten-logik).
+ 


### PR DESCRIPTION
Ich habe hier mal wichtige Links zu JavaScript und dem Adapter ergänzt. Aufgrund https://forum.iobroker.net/post/271751 hier unter Tutorials eingefügt. Auffällig ist, dass der Titel laut Seitenleiste "Tutorial" unter dem Hauptpunkt "Tutorials" ist, aber der Dateiname "updates.md". Sollte vielleicht auch gelegentlich korrigiert werden.