### PR TITLE
add level.open/close.blind roles

### DIFF
--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -79,9 +79,7 @@
 * `value.power.consumption` (unit=Wh or KWh)
 * `value.direction`       - (common.type=number ~~or string~~, indicates up/down, left/right, 4-way switches, wind-direction, ... )
 * `value.curtain`         - actual position of curtain
-* `value.blind`           - actual position of blind
-* `value.open.blind`      - actual position of blind position in % open with 100% = fully open and 0% = fully closed
-* `value.close.blind`     - actual position of blind position in % close with 100% = fully closed and 0% = fully opened
+* `value.blind`           - actual position of blind (100% = fully open, 0% = fully closed)
 * `value.tilt`            - actual tilt position
 * `value.open.tilt`       - actual tilt position in % open with 100% = fully open and 0% = fully closed.
 * `value.close.tilt`      - actual tilt position in % close with 100% = fully closed and 0% = fully open.
@@ -130,9 +128,7 @@ With **levels** you can control or set some number value.
 * `level`
 * `level.co2`             - 0-100% ait quality
 * `level.dimmer`          - brightness is dimmer too
-* `level.blind`           - set blind position
-* `level.open.blind`      - set blind position in % open with 100% = fully open and 0% = fully closed
-* `level.close.blind`     - set blind position in % close with 100% = fully closed and 0% = fully opened
+* `level.blind`           - set blind position (100% = fully open, 0% = fully closed)
 * `level.temperature`     - set desired temperature
 * `level.valve`           - set point for valve position
 * `level.color.red`
@@ -150,9 +146,7 @@ With **levels** you can control or set some number value.
 * `level.volume`         - (min=0, max=100) - sound volume, but min, max can differ. min < max
 * `level.volume.group`   - (min=0, max=100) - sound volume, for the group of devices
 * `level.curtain`        - set the curtain position
-* `level.tilt`           - set the tilt position of blinds
-* `level.open.tilt`      - set the tilt position in % open with 100% = fully open and 0% = fully closed.
-* `level.close.tilt`     - set the tilt position in % close with 100% = fully closed and 0% = fully open.
+* `level.tilt`           - set the tilt position of blinds (100% = fully open, 0% = fully closed)
 
 ## Switches (booleans, read-write)
 

--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -34,9 +34,14 @@
 * `button`
 * `button.long`
 * `button.stop`           - e.g. rollo stop,
+* `button.stop.tilt`
 * `button.start`
 * `button.open.door`
 * `button.open.window`
+* `button.open.blind`
+* `button.open.tilt`
+* `button.close.blind`
+* `button.close.tilt`
 * `button.mode.`*
 * `button.mode.auto`
 * `button.mode.manual`
@@ -75,7 +80,11 @@
 * `value.direction`       - (common.type=number ~~or string~~, indicates up/down, left/right, 4-way switches, wind-direction, ... )
 * `value.curtain`         - actual position of curtain
 * `value.blind`           - actual position of blind
+* `value.open.blind`      - actual position of blind position in % open with 100% = fully open and 0% = fully closed
+* `value.close.blind`     - actual position of blind position in % close with 100% = fully closed and 0% = fully opened
 * `value.tilt`            - actual tilt position
+* `value.open.tilt`       - actual tilt position in % open with 100% = fully open and 0% = fully closed.
+* `value.close.tilt`      - actual tilt position in % close with 100% = fully closed and 0% = fully open.
 * `value.lock`            - actual position of lock
 * `value.speed`           - wind speed
 * `value.pressure`        - (unit: mbar)
@@ -122,6 +131,8 @@ With **levels** you can control or set some number value.
 * `level.co2`             - 0-100% ait quality
 * `level.dimmer`          - brightness is dimmer too
 * `level.blind`           - set blind position
+* `level.open.blind`      - set blind position in % open with 100% = fully open and 0% = fully closed
+* `level.close.blind`     - set blind position in % close with 100% = fully closed and 0% = fully opened
 * `level.temperature`     - set desired temperature
 * `level.valve`           - set point for valve position
 * `level.color.red`
@@ -140,6 +151,8 @@ With **levels** you can control or set some number value.
 * `level.volume.group`   - (min=0, max=100) - sound volume, for the group of devices
 * `level.curtain`        - set the curtain position
 * `level.tilt`           - set the tilt position of blinds
+* `level.open.tilt`      - set the tilt position in % open with 100% = fully open and 0% = fully closed.
+* `level.close.tilt`     - set the tilt position in % close with 100% = fully closed and 0% = fully open.
 
 ## Switches (booleans, read-write)
 

--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -80,9 +80,7 @@
 * `value.direction`       - (common.type=number ~~or string~~, indicates up/down, left/right, 4-way switches, wind-direction, ... )
 * `value.curtain`         - actual position of curtain
 * `value.blind`           - actual position of blind (100% = fully open, 0% = fully closed)
-* `value.tilt`            - actual tilt position
-* `value.open.tilt`       - actual tilt position in % open with 100% = fully open and 0% = fully closed.
-* `value.close.tilt`      - actual tilt position in % close with 100% = fully closed and 0% = fully open.
+* `value.tilt`            - actual tilt position (100% = fully open, 0% = fully closed)
 * `value.lock`            - actual position of lock
 * `value.speed`           - wind speed
 * `value.pressure`        - (unit: mbar)


### PR DESCRIPTION
After the discussion in the boards it seems there is no consensus on how level.blind has to be interpreted. This makes it hard for visualisations and other adapters that try to make things more smart to control them or interpret readings from value.blind. So the (middle ground)[https://forum.iobroker.net/topic/33995/umfrage-rolladenposition-in-was-ist-logischer/85] was to add two roles which make the interpretation more clear. 

I added those new roles here for level.open/close.blind, level.open/close.tilt, the same for value and some buttons. I plan on using them in a future PR for type-detector.