### PR TITLE
Update objectsschema.md - characters not allowed in IDs

### DIFF
--- a/docs/en/dev/objectsschema.md
+++ b/docs/en/dev/objectsschema.md
@@ -19,9 +19,7 @@ The following chapters describe Database Schema.
 ## IDs
 ID is a string with a maximum length of 240 bytes, hierarchically structured, levels separated by dots.
 
-Following characters are prohibited to use in IDs: `[]*,;'"&#96:<>\\?`.
-
-It is not suggested to use `^$()/` too.
+Following characters are prohibited to use in IDs: `._\\-/ :!#$%&()+=@^{}|~`.
 
 The ID has different levels. Each level is determined by the dot. Example: `system.adapter.admin.0`
 - `system` - is the name space for system objects

--- a/docs/en/dev/objectsschema.md
+++ b/docs/en/dev/objectsschema.md
@@ -19,7 +19,7 @@ The following chapters describe Database Schema.
 ## IDs
 ID is a string with a maximum length of 240 bytes, hierarchically structured, levels separated by dots.
 
-Following characters are prohibited to use in IDs: `[]*,;'"&#96;<>\\?`.
+Following characters are prohibited to use in IDs: `[]*,;'"&#96:<>\\?`.
 
 It is not suggested to use `^$()/` too.
 


### PR DESCRIPTION
based on this discussion (https://forum.iobroker.net/topic/46975/vis-widgethintergrund-farbe-durch-objektdatenpunkt-steuern/6), colons (:) are not allowed in IDs. In the list of not allowed characters in IDs, the semicolon (;) is listed twice. I guess one of the two should actually be a colon.