### PR TITLE
new links for downloads

### DIFF
--- a/engine/front-end/public/downloads.json
+++ b/engine/front-end/public/downloads.json
@@ -11,7 +11,7 @@
   {
     "file": "https://hub.docker.com/r/buanet/iobroker/",
     "platform": "Docker",
-    "date": "20221108",
+    "date": "",
     "device": "Docker",
     "details": "Docker image",
     "picture": "docker.png",
@@ -20,7 +20,7 @@
   {
     "file": "https://github.com/buanet/ioBroker.raspberry-os/releases",
     "platform": "Raspberry OS",
-    "date": "20221108",
+    "date": "",
     "device": "Raspberry Pi",
     "details": "Raspberry OS Image with ioBroker",
     "picture": "Pi4.png",

--- a/engine/front-end/public/downloads.json
+++ b/engine/front-end/public/downloads.json
@@ -15,10 +15,10 @@
     "device": "Docker",
     "details": "Docker image",
     "picture": "docker.png",
-    "info": "https://smarthome.buanet.de/docker/container-images/iobroker/"
+    "info": "https://docs.buanet.de/iobroker-docker-image/"
   },
   {
-    "file": "ioBroker_Image_RPi_v1.2.0_latest.zip",
+    "file": "https://github.com/buanet/ioBroker.raspberry-os/releases",
     "platform": "Raspberry OS",
     "date": "20210809",
     "device": "Raspberry Pi",

--- a/engine/front-end/public/downloads.json
+++ b/engine/front-end/public/downloads.json
@@ -11,7 +11,7 @@
   {
     "file": "https://hub.docker.com/r/buanet/iobroker/",
     "platform": "Docker",
-    "date": "20190607",
+    "date": "",
     "device": "Docker",
     "details": "Docker image",
     "picture": "docker.png",
@@ -20,7 +20,7 @@
   {
     "file": "https://github.com/buanet/ioBroker.raspberry-os/releases",
     "platform": "Raspberry OS",
-    "date": "20210809",
+    "date": "",
     "device": "Raspberry Pi",
     "details": "Raspberry OS Image with ioBroker",
     "picture": "Pi4.png",

--- a/engine/front-end/public/downloads.json
+++ b/engine/front-end/public/downloads.json
@@ -11,7 +11,7 @@
   {
     "file": "https://hub.docker.com/r/buanet/iobroker/",
     "platform": "Docker",
-    "date": "",
+    "date": "20221108",
     "device": "Docker",
     "details": "Docker image",
     "picture": "docker.png",
@@ -20,7 +20,7 @@
   {
     "file": "https://github.com/buanet/ioBroker.raspberry-os/releases",
     "platform": "Raspberry OS",
-    "date": "",
+    "date": "20221108",
     "device": "Raspberry Pi",
     "details": "Raspberry OS Image with ioBroker",
     "picture": "Pi4.png",


### PR DESCRIPTION
Is it possible to simply remove the date for Docker and Raspberry image?

The download of the image is no longer direct but from releases at the iobroker raspberry os repo.  

Regards,
André 