### PR TITLE
add roles level.min/max/default

### DIFF
--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -138,6 +138,9 @@ With **levels**, you can control or set some number value.
 `common.type=number, common.write=true`
 
 * `level`
+* `level.min`             - minimum level allowed  
+* `level.max`             - maximum level allowed
+* `level.default`         - default level
 * `level.dimmer`          - brightness is dimmer too
 * `level.blind`           - set blind position (max = fully open, min = fully closed)
 * `level.temperature`     - set desired temperature


### PR DESCRIPTION
Add roles level.min/max/default as counterparts to value.min/max/default

Those rules should allow to specifiy a dedicated role for minimum / maximum and default values for opration od devices which are stored / controlled using states.

@Apollon77 
@GermanBluefox 
@Garfonso 

Realtes to https://github.com/ioBroker/ioBroker.type-detector/issues/35 part a