### PR TITLE
add roles time.difference, time.timeout and time.interval

### DIFF
--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -413,7 +413,7 @@ Special roles for media players
 * `url.same`               - open URL in this window
 * `url.audio`              - URL for audio file
 * `text.phone`             - phone number
-* `time.difference`        - time difference in ms (common.type=number), i.e. time since last update, duration of operation, time until next try, ...
+* `time.span`              - time difference in ms (common.type=number), i.e. time since last update, duration of operation, time until next try, ...
 * `time.interval`          - intervall value in ms (common.type=number), i.e. some polling interval
 * `time.timeout`           - timeout value in ms (common.type=number), i.e. timeouts for communication requests
 * `chart`                  - JSON array with chart data, like `[{ts: 1678575600000, val: 1}, {ts: 1678579200000, val: 2}]`

--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -413,6 +413,9 @@ Special roles for media players
 * `url.same`               - open URL in this window
 * `url.audio`              - URL for audio file
 * `text.phone`             - phone number
+* `time.difference`        - time difference in ms (common.type=number), i.e. time since last update, duration of operation, time until next try, ...
+* `time.interval`          - intervall value in ms (common.type=number), i.e. some polling interval
+* `time.timeout`           - timeout value in ms (common.type=number), i.e. timeouts for communication requests
 * `chart`                  - JSON array with chart data, like `[{ts: 1678575600000, val: 1}, {ts: 1678579200000, val: 2}]`
 
 * `adapter.messagebox`     (`common.type=object, common.write=true`) used to send messages to email, pushover and other adapters


### PR DESCRIPTION
Currently no roles exist to specify a timeout values for i.e. for network operations. And the same applies for states controlling an intervall for recurrent operations. time.difference would be useful to specify the difference of 2 times, ie. the duration of last operation or the deviation from a planned timestamp

I suggest to specify the values as ms as ms is the technical unit für javascript timers 

@Apollon77 
@GermanBluefox 
@Garfonso 

Solves https://github.com/ioBroker/ioBroker.type-detector/issues/36