### PR TITLE
Add several roles for level states

### DIFF
--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -138,7 +138,21 @@ With **levels**, you can control or set some number value.
 `common.type=number, common.write=true`
 
 * `level`
-* `level.dimmer`          - brightness is dimmer too
+* `level.humidity`        - humidity as a setpoint, i.e. for humifiers / climatecontrols
+* `level.battery`         - battery target voltage / capacity i.e.for loading
+* `level.battery.min`     - battery minimum voltage / capacity
+* `level.battery.max`     - battery maximum voltage / capacity
+* `level.valve`           - opening value for valves
+* `level.pressure`        -
+* `level.pressure.min`    - minimum air or oil pressure value allowed
+* `level.pressure.max`    - maximum air or oil pressure value allowed
+* `level.voltage`         - target voltage for generators
+* `level.voltage.min`     - minimum voltage for generators
+* `level.voltage.max`     - maximum voltage for generators
+* `level.current`         - target current for i.e. loading battery devices
+* `level.current.min`     - minimum current for i.e. loading battery devices
+* `level.current.max`     - maximum current for i.e. loading battery devices
+* `level.fill -> level.fill - setpoint for any container fill level states* `level.dimmer`          - brightness is dimmer too
 * `level.blind`           - set blind position (max = fully open, min = fully closed)
 * `level.temperature`     - set desired temperature
 * `level.valve`           - set point for valve position


### PR DESCRIPTION
This PR addes several roles which already exists for VALUEs to LEVELs so that input states controlling those objects could use the same roiles as the corresponding values states.

@Apollon77 
@GermanBluefox 
@Garfonso

Fixes  https://github.com/ioBroker/ioBroker.type-detector/issues/35