### PR TITLE
cleanup power and energy mix

### DIFF
--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -89,10 +89,18 @@ in the [Type-detector repository](https://github.com/ioBroker/ioBroker.type-dete
 * `value.gps`             - longitude and latitude together like '5.56;43.45'
 * `value.gps.accuracy`    - accuracy of current gps measurement
 * `value.gps.radius`      - radius of current gps measurement
-* `value.power`           - actual power (unit=W or KW)
-* `value.power.consumption` - energy consumption (unit=Wh or KWh)
-* `value.power.production` - energy production (unit=Wh or KWh)
-* `value.power.reactive`  - reactive power (unit=VAr)
+* ~~`value.power.consumption` - energy consumption (unit=Wh or KWh)~~
+* ~~`value.power.production` - energy production (unit=Wh or KWh)
+* `value.energy`          - energy (unit=Wh, kWh or m3 for gasoline) 
+* `value.energy.active`   - active energy (unit=Ws, Wh, kWh)
+* `value.energy.reactive` - reactive energy (unit=vars, kVarh)
+* `value.energy.consumed` - energy consumed (unit=Ws, Wh, kWWh)
+* `value.energy.produced` - power produced (unit=Ws, Wh or KWh)
+* `value.power`           - energy power (unit=W or KW)
+* `value.power.active`    - active power (unit=W, kW)
+* `value.power.reactive`  - reactive power (unit=var, kVar)
+* `value.power.consumed`  - power consumed (unit=W or KW)
+* `value.power.produced`  - power produced (unit=W or KW)
 * `value.direction`       - (common.type=number ~~or string~~, indicates up/down, left/right, 4-way switches, wind-direction, ... )
 * `value.curtain`         - actual position of curtain
 * `value.blind`           - actual position of blind (`max = fully open, min = fully closed`)


### PR DESCRIPTION
Currently power is used for (electrical) pwoer AND incorrectly for (electrical) energy too.

So I suggest the following changes

DEPRECATE 8but do not reuse) value.power.consumtioon and production which are names "power" (de: Leistung) but specify a unit of kWh (which is an energy unit)

* ~~`value.power.consumption` - energy consumption (unit=Wh or KWh)~~
* ~~`value.power.production` - energy production (unit=Wh or KWh)

Add the the following roles for ENERGY (Energie)
* `value.energy`          - energy (unit=Wh, kWh or m3 for gasoline)  
* `value.energy.active`   - active energy (unit=Ws, Wh, kWh)
* `value.energy.reactive` - reactive energy (unit=vars, kVarh)
* `value.energy.consumed` - energy consumed (unit=Ws, Wh, kWWh)
* `value.energy.produced` - power produced (unit=Ws, Wh or KWh)

Add the the following roles for POWER (Leistung)
* `value.power`           - energy power (unit=W or KW) (already exists)
* `value.power.active`    - active power (unit=W, kW)
* `value.power.reactive`  - reactive power (unit=var, kVar)
* `value.power.consumed`  - power consumed (unit=W or KW)
* `value.power.produced`  - power produced (unit=W or KW)

-------

Deutsche Erläuterungen zur Diskussion:

Generell beschreibt POWER eine LEISTUNG. Die Eionheit der (elektr.) Leistung ist W / kW.
power alleine ist als allgemeine Role für eine Leistung bereits vorhanden und i.O.
power.active sollte spezifiziert werden um die Wirkleistung explizit angeben zu können um sie ggF von der Blindleistung (power.reactive) zu unterscheiden. Eine explizite Rolle für die Scheinleistung kann m.E. entfallen. Hier kann power alleine verwendet werden.

Die ENERGIE (ENERGY) wird für elektr. Größen in Ws / Wh / kWh gemessen. Hier schlage ich äquivalente Rollen vor:
energy alleine ist als allgemeine Rolle für einen Energiewert vorgesehen. Als Einheit sollte Ws / Wh und kWh verwendet werden. Aber auch m3 würde ich für Gas erlauben, da der Gasbezug  meist in m3 gemessen wird (und dann in kWh abgerechnet wird). Dadurch bräcuhte man keine extra Rolle für Gas-Volumina. (Im Bedarffall könnte man aber sowas auch einführen - wäre extra zu besprechen, da dann auch l (Liter f+ür Treibstoffe(, t (Tonnen für Pallets) , ... ins Gesprächa kommen.
energy.active und energy.reactive stünden für Wirkenergie und Blindenergie zur Verfügung.

Für eine Unetrscheidung zwoschen bezogener Leistugn bez. Energie udn erzeugter Leistung Energie würde ich
power.consumed / power.produced und energy.consumed/energy.produced vorschlagen.

Bei Bezug / Erzeugung rollen würde ich vorschlagen nicht weiter zwischen Wirk und Blingleistung/-energie zu unterscheiden da die Rollennmane sonst zwangsläufig zu lang würden. Falls dies stört, würde ich alternativ vorschlagen consumed / produced generell durch imn / out zu ersetzen, also power,in, power,out, ... zu verwenden. In diesem Fall wäre energy..reactive.in etc. noch möglich. Ich kann den Bedarf dafür nicht abschätzen, glaube aber dass er gering ist.

BITTE UM KOMMENTARE / ÄNDERUNGSVORSCHLÄGE oder ggF auch OKs.

@Apollon77 
@GermanBluefox 
@Garfonso 
@klein0r 