### PR TITLE
Update stateroles.md - add button.resume

### DIFF
--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -47,6 +47,7 @@ in the [Type-detector repository](https://github.com/ioBroker/ioBroker.type-dete
 * `button.stop`           - e.g. rollo stop,
 * `button.stop.tilt`
 * `button.start`
+* `button.resume`
 * `button.open.door`
 * `button.open.window`
 * `button.open.blind`


### PR DESCRIPTION
Many devices have a start / stop /resume functionality. Currently only start and stop buttons are available. Adding resume seems to be appopiate.

i.e. see https://github.com/ioBroker/ioBroker.repositories/pull/2456#issuecomment-1648709513

@DutchmanNL
Please comment eventually