### PR TITLE
Fix table layout even more

### DIFF
--- a/docs/de/install/requirements.md
+++ b/docs/de/install/requirements.md
@@ -8,8 +8,8 @@ lastChanged: "29.05.2024"
 | Betriebssystem | Varianten | Hardwareumgebungen (z.B.) | Mindestanforderungen für ioBroker | Empfohlene Ressourcen für ioBroker (2) 
 | --------- | --------- | --------- | --------- | --------- |
 | Linux-Distributionen | Empfehlung: Debian inkl. entsprechender Derivate (1) | Raspberry PI,  Einplantinencomputer, Mini-PC (z.B. NUC), Hardware mit einer Virtualisierungsumgebung | 2 GB RAM, 32 GB Speicherkapazität  | >= 4 GB (besser 6 GB - 8 GB) RAM , >= 64 GB Speicherkapazität 
-Docker | | Mini-PC (z.B. NUC), NAS (3) | 2 GB RAM, 32 GB Speicherkapazität  | >= 4 GB (besser 6 GB - 8 GB) RAM , >= 64 GB Speicherkapazität 
-Windows | | PC, Mini-PC (z.B. NUC)| 4 GB RAM, 50 GB Speicherkapazität  (inkl. OS) | 8 GB RAM, 100 GB Speicherkapazität  (inkl. OS)
+| Docker | | Mini-PC (z.B. NUC), NAS (3) | 2 GB RAM, 32 GB Speicherkapazität  | >= 4 GB (besser 6 GB - 8 GB) RAM , >= 64 GB Speicherkapazität 
+| Windows | | PC, Mini-PC (z.B. NUC)| 4 GB RAM, 50 GB Speicherkapazität  (inkl. OS) | 8 GB RAM, 100 GB Speicherkapazität  (inkl. OS)
 
 
 


### PR DESCRIPTION
The second and third row should now render as part of the table as well.

The previous fix for this table looked good in Preview on Github but it appears that the site https://www.iobroker.net/#de/documentation/install/requirements.md renders Markdown slightly different and only the first row in the table was fixed on that site. This change should fix the entire table on the site.