### PR TITLE
Change "code" text to normal to allow auto-translation

### DIFF
--- a/docs/de/install/linux.md
+++ b/docs/de/install/linux.md
@@ -16,7 +16,7 @@ Vor der Installation prüfe bitte, ob das System alle notwendigen [Installations
 ## Wichtige Punkte die beachtet werden müssen
 
 - KEINE Installation von ioBroker als **root** User! Das Ausführen des Installationsskriptes **muss** als ein normaler User durchgeführt werden,
-durch diesen User wird auch das System zukünftig administriert. Der `normale` User sollte, nicht `iobroker` heißen, es sollte der bei der Basisinstallation, angelegte User sein.
+durch diesen User wird auch das System zukünftig administriert. Der normale User sollte, nicht `iobroker` heißen, es sollte der bei der Basisinstallation, angelegte User sein.
 - Benötigte Hardware: Raspberry Pi mit Raspberry OS oder jede andere beliebige Hardware mit einem gängigen Linux. Empfohlen wird jedoch Debian, Ubuntu oder eine der darauf basierenden Distributionen 
 - Einsteiger sollten mit Debian / Raspberry Pi OS / Armbian ohne  zusätzliche Virtualisierungsschicht wie Docker oder Proxmox beginnen, da mit jeder weiteren Ebene weiterer administrativer Aufwand und mögliche Problemquellen hinzukommen
 - Installiere dein Betriebssystem als Servervariante ohne einen Desktop


### PR DESCRIPTION
The word "normale" was marked as `code`, which meant that it was not automatically translated to English. This change fixes that by changing it to normal text.

Having it marked as code was a weird choice: if emphasis is required, **bold** or *italic* is a better choice.