### PR TITLE
Fix line breaks and add dots at end of sentences

### DIFF
--- a/docs/de/install/linux.md
+++ b/docs/de/install/linux.md
@@ -15,14 +15,12 @@ Vor der Installation prüfe bitte, ob das System alle notwendigen [Installations
 
 ## Wichtige Punkte die beachtet werden müssen
 
-- KEINE Installation von ioBroker als **root** User! Das Ausführen des Installationsskriptes **muss** als ein normaler User durchgeführt werden,
-durch diesen User wird auch das System zukünftig administriert. Der `normale` User sollte, nicht `iobroker` heißen, es sollte der bei der Basisinstallation, angelegte User sein.
-- Benötigte Hardware: Raspberry Pi mit Raspberry OS oder jede andere beliebige Hardware mit einem gängigen Linux. Empfohlen wird jedoch Debian, Ubuntu oder eine der darauf basierenden Distributionen 
-- Einsteiger sollten mit Debian / Raspberry Pi OS / Armbian ohne  zusätzliche Virtualisierungsschicht wie Docker oder Proxmox beginnen, da mit jeder weiteren Ebene weiterer administrativer Aufwand und mögliche Problemquellen hinzukommen
-- Installiere dein Betriebssystem als Servervariante ohne einen Desktop
-  - ioBroker arbeitet als Server 24/7 und wird über Terminalprogramme wie Putty, Powershell o.ä. administriert. Eine Desktop Umgebung verbraucht unnötige Ressourcen und vergrößert das Fehlerpotential
-- Hardware Raspberry Pi: Es ist wichtig ein gutes Netzteil zu verwenden. Mit schwachem Netzteil (z.B. Handy Netzteile) 
-sind Stabilitätsprobleme zu erwarten
+- KEINE Installation von ioBroker als **root** User! Das Ausführen des Installationsskriptes **muss** als ein normaler User durchgeführt werden, durch diesen User wird auch das System zukünftig administriert. Der `normale` User sollte, nicht `iobroker` heißen, es sollte der bei der Basisinstallation, angelegte User sein.
+- Benötigte Hardware: Raspberry Pi mit Raspberry OS oder jede andere beliebige Hardware mit einem gängigen Linux. Empfohlen wird jedoch Debian, Ubuntu oder eine der darauf basierenden Distributionen.
+- Einsteiger sollten mit Debian / Raspberry Pi OS / Armbian ohne  zusätzliche Virtualisierungsschicht wie Docker oder Proxmox beginnen, da mit jeder weiteren Ebene weiterer administrativer Aufwand und mögliche Problemquellen hinzukommen.
+- Installiere dein Betriebssystem als Servervariante ohne einen Desktop.
+- ioBroker arbeitet als Server 24/7 und wird über Terminalprogramme wie Putty, Powershell o.ä. administriert. Eine Desktop Umgebung verbraucht unnötige Ressourcen und vergrößert das Fehlerpotential.
+- Hardware Raspberry Pi: Es ist wichtig ein gutes Netzteil zu verwenden. Mit schwachem Netzteil (z.B. Handy Netzteile) sind Stabilitätsprobleme zu erwarten.
 
 
 ## Raspberry Pi 


### PR DESCRIPTION
Parts of some sentences were broken up into separate paragraphs when rendered as Markdown because an end-of-line was added in the middle of the sentence and the next line was not indented.

Rather than add indentation on the next lines, I've opted to remove the end-of-lines. This seems more reasonable in a time where different devices have different screen width and auto-line-wrap is implemented in almost every editor.