### PR TITLE
Remove Raspberry Image from downloads

### DIFF
--- a/engine/front-end/public/downloads.json
+++ b/engine/front-end/public/downloads.json
@@ -15,14 +15,5 @@
     "details": "Docker image",
     "picture": "docker.png",
     "info": "https://docs.buanet.de/iobroker-docker-image/"
-  },
-  {
-    "file": "https://github.com/buanet/ioBroker.raspberry-os/releases",
-    "platform": "Raspberry OS",
-    "date": "",
-    "device": "Raspberry Pi",
-    "details": "Raspberry OS Image with ioBroker",
-    "picture": "Pi4.png",
-    "info": "https://forum.iobroker.net/topic/41520/raspberry-os-lite-image-for-with-iobroker"
   }
 ]


### PR DESCRIPTION
As this is no longer maintained, let's remove the Raspberry Image from the downloads section of the ioBroker website.

Regards,
 André