### PR TITLE
Add links to install description in requirements.md

### DIFF
--- a/docs/de/install/requirements.md
+++ b/docs/de/install/requirements.md
@@ -7,9 +7,9 @@ lastChanged: "29.05.2024"
 ## Systemanforderungen
 | Betriebssystem | Varianten | Hardwareumgebungen (z.B.) | Mindestanforderungen für ioBroker | Empfohlene Ressourcen für ioBroker (2) 
 | --------- | --------- | --------- | --------- | --------- |
-| Linux-Distributionen | Empfehlung: Debian inkl. entsprechender Derivate (1) | Raspberry PI,  Einplantinencomputer, Mini-PC (z.B. NUC), Hardware mit einer Virtualisierungsumgebung | 2 GB RAM, 32 GB Speicherkapazität  | >= 4 GB (besser 6 GB - 8 GB) RAM , >= 64 GB Speicherkapazität 
-| Docker | | Mini-PC (z.B. NUC), NAS (3) | 2 GB RAM, 32 GB Speicherkapazität  | >= 4 GB (besser 6 GB - 8 GB) RAM , >= 64 GB Speicherkapazität 
-| Windows | | PC, Mini-PC (z.B. NUC)| 4 GB RAM, 50 GB Speicherkapazität  (inkl. OS) | 8 GB RAM, 100 GB Speicherkapazität  (inkl. OS)
+| [Linux-Distributionen](./#de/documentation/install/linux.md) | Empfehlung: Debian inkl. entsprechender Derivate (1) | Raspberry PI,  Einplantinencomputer, Mini-PC (z.B. NUC), Hardware mit einer Virtualisierungsumgebung | 2 GB RAM, 32 GB Speicherkapazität  | >= 4 GB (besser 6 GB - 8 GB) RAM , >= 64 GB Speicherkapazität 
+| [Docker](./#de/documentation/install/docker.md) | | Mini-PC (z.B. NUC), NAS (3) | 2 GB RAM, 32 GB Speicherkapazität  | >= 4 GB (besser 6 GB - 8 GB) RAM , >= 64 GB Speicherkapazität 
+| [Windows](./#de/documentation/windows.md) | | PC, Mini-PC (z.B. NUC)| 4 GB RAM, 50 GB Speicherkapazität  (inkl. OS) | 8 GB RAM, 100 GB Speicherkapazität  (inkl. OS)
 
 
 


### PR DESCRIPTION
Especially on mobile phone, it is not obvious how to continue from this page. This page might be a useful "landing page" for an installation documentation link, though, with this links added.

Checked the other languages, they seem to be created from German, so no change needed.
I took the base link from the linux install documentation, that links back to this page. So I hope the format is ok.

