### PR TITLE
Update stateroles.md - add level.brightness

### DIFF
--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -166,6 +166,7 @@ With **levels**, you can control or set some number value.
 * `level.frequency.min`   - minimum frequency for generators or for power grid alarms
 * `level.frequency.max`   - maximum frequency for generators or for power grid alarms
 * `level.fill`            - setpoint for any container fill level states 
+* `level.brightness`      - luminance level (unit: lux, )
 * `level.min`             - minimum level allowed  
 * `level.max`             - maximum level allowed
 * `level.default`         - default level


### PR DESCRIPTION
adding level.brightness

value.brightness already exists.
AND level.brightness is already mentioned at introduction example at head of document too. So ist very likely that it simply is missing in the enumeration. 4

