### PR TITLE
Update stateroles.md - add switch.feature

### DIFF
--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -221,6 +221,7 @@ Switch controls a boolean device (`true = ON, false = OFF`)
 * `switch.mode.moonlight` - moon light mode on/off
 * `switch.mode.color`     - color mode on/off
 * `switch.gate`           - closes(false) or opens(true) the gate
+* `switch.feature`        - switch on/off a feature. In contrast to modes which usually are exclusive, this should be independet of other settings
 
 ## Air condition or thermostat
 * `level.mode.fan`        - `AUTO, HIGH, LOW, MEDIUM, QUIET, TURBO`


### PR DESCRIPTION
Add the role `switch.feature` do distinguish switching on / off a feature like "childlock" or "open window detection" from switching power or switching a mode. 

It could be useful in the future to add a generic "features" thingie in types. 

Loosely connected to this issue in type-detector https://github.com/ioBroker/ioBroker.type-detector/issues/118 From the type-detector perspective the role `switch` should not be used at all.