### PR TITLE
sorting-check fixed

### DIFF
--- a/info/processNews.js
+++ b/info/processNews.js
@@ -4,16 +4,16 @@ const json = readFileSync(`${__dirname}/news.json`, 'utf8');
 let news;
 try {
     news = JSON.parse(json);
-    news.sort((a, b) => b.created - a.created);
+    news.sort((a, b) => Date.parse(a.created) - Date.parse(b.created));
 } catch (e) {
     throw new Error(`Cannot parse news.json: ${e}`);
 }
-if (json !== JSON.stringify(news, null, 2)) {
+if (JSON.stringify(JSON.parse(json), null, 2) !== JSON.stringify(news, null, 2)) {
     if (process.argv.includes('--check')) {
         throw new Error('News are not sorted');
     } else {
         writeFileSync('news.json', JSON.stringify(news, null, 2));
     }
+} else {
+    console.log('News are sorted')
 }
-
-


### PR DESCRIPTION
This PR fixes the sorting check

a) Sorting did not really work as subtracting two strings did not work as desired. Explizit conversion to timestamps has been added and comparison has been inverted to keep oldes entry as first entry

b) Whitespace differences are now eleminated from comparison by explicit parsing and stringifying original test too

@Apollon77 
Please review