### PR TITLE
Update state roles documentation for level.effect

### DIFF
--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -214,9 +214,10 @@ With **levels**, you can control or set some number value.
 * `level.color.saturation`
 * `level.color.rgb`       - hex color like `#rrggbb` (`common.type=string`)
 * `level.color.rgbw`      - hex color like `#rrggbbww` (`common.type=string`)
-* `level.color.cie`       - cie color in form `[x, y]` (`common.type=string)
+* `level.color.cie`       - cie color in form `[x, y]` (`common.type=string`)
 * `level.color.luminance`
 * `level.color.temperature` - color temperature in K° `2200 warm-white, 6500° cold white`
+* `level.effect`          - effect, usually for lights. Should have list of possible effects in `common.states`. (`common.type=string`).
 * `level.timer`
 * `level.timer.sleep`    - sleep timer. 0 - off, or in minutes
 * ...


### PR DESCRIPTION
Added description for 'level.effect' and fixed formatting for 'level.color.cie'.

Some lights offer a list of effects that the device itself can do, like flashing or fading or whatever (some can do quite complex stuff). Adapters today implement that as state with `common.type=string` and a list of possible effects in `common.states`.  I'd like to add support for an effect state in type-detector for most of the light types (and after that add it to lovelace, because the frontend seems to support that already).

`common.type=string` is not really correct for `level`. But there are already some exceptions to that rule, mostly used for lights already.