### PR TITLE
Add state roles used by the type detector

### DIFF
--- a/docs/de/dev/stateroles.md
+++ b/docs/de/dev/stateroles.md
@@ -60,6 +60,7 @@ Falls keine passende Rolle gefunden werden kann oder der Anwendungsfall nicht sp
 * `sensor.alarm` - einige gängige Alarme
 * `sensor.alarm.flood` - Wasserleckage
 * `sensor.alarm.fire` - Feuermelder
+* `sensor.alarm.co` - Kohlenmonoxid erkannt
 * `sensor.alarm.secure` - Tür geöffnet, Fenster geöffnet oder Bewegung erkannt, während der Alarm aktiv ist.
 * `sensor.alarm.power` - Keine Stromversorgung (`voltage = 0`)
 * `sensor.light` - Rückmeldung der Lampe, dass sie eingeschaltet ist
@@ -121,12 +122,18 @@ Benutzeroberflächen sollten den Wert dieses Zustands weder auslesen noch erwart
 * `value.rn`              - Radon (unit: Bq/m³)
 * `value.tvoc`            - Total volatile organic compounds (unit: µg/m³ or ppb)
 * `value.airquality`      - Air quality index (AQI)
+* `value.so2`             - Schwefeldioxid (Einheit: µg/m³ oder ppm)
+* `value.co.level`, `value.co2.level`, `value.no2.level`, `value.o3.level`, `value.ch2o.level`, `value.pm1.level`, `value.pm25.level`, `value.pm10.level`, `value.rn.level`, `value.tvoc.level`, `value.so2.level` - qualitative Stufe der gleichnamigen Konzentration (`common.states={"0": "UNKNOWN", "1": "LOW", "2": "MEDIUM", "3": "HIGH", "4": "CRITICAL"}`)
 * `value.brightness` - Leuchtdichtewert (Einheit: Lux)
 * `value.min`
 * `value.max`
 * `value.default`
 * `value.battery` - Akkuladestand
 * `value.valve` - Ventilpegel
+* `value.filter` - verbleibender Zustand eines Filters (Einheit: %)
+* `value.filter.carbon` - verbleibender Zustand eines Aktivkohlefilters (Einheit: %)
+* `value.flow` - Durchfluss einer Flüssigkeit oder eines Gases (Einheit: m³/h)
+* `value.rssi` - Empfangsfeldstärke eines Funkgerätes (Einheit: dBm)
 * `value.time` - getTime() des Date()-Objekts
 * `value.timer` - Dauer in Sekunden (entspricht im Lese-/Schreibmodus `level.timer`)
 * `value.interval` (common.unit='sec') - Intervall in Sekunden (kann 0,1 oder weniger sein)
@@ -156,7 +163,7 @@ Benutzeroberflächen sollten den Wert dieses Zustands weder auslesen noch erwart
 * `value.tilt` - tatsächliche Neigungsposition (`max = vollständig geöffnet, min = vollständig geschlossen`)
 * `value.lock` - tatsächliche Position der Sperre
 * `value.speed` - Windgeschwindigkeit
-* `value.pressure` - (Einheit: mbar)
+* `value.pressure` - (Einheit: mbar, `hPa` ist derselbe Wert und wird ebenfalls akzeptiert)
 * `value.distance`
 * `value.distance.visibility`
 * `value.severity` – eine Angabe zum Schweregrad (Zustände können angegeben werden), je höher, desto wichtiger
@@ -178,6 +185,7 @@ Daher kann ein Indikator nicht allein im Kanal vorkommen. Er muss Teil eines and
 
 * `Indikator`
 * `indicator.working` - zeigt an, dass das Zielsystem gerade eine Aktion ausführt, z. B. das Öffnen von Jalousien oder Schlössern.
+* `indicator.working.test` - ein Selbsttest des Gerätes läuft
 * `indicator.reachable` - Gibt an, ob ein Gerät online ist
 * `indicator.connected` – wird nur für Instanzen verwendet. Verwenden Sie `indicator.reachable` für Geräte.
 * `indicator.direction` - `true` - Aufwärts/Eröffnung, `false` - Abwärts/Schluss. Verwenden Sie besser `value.direction`.
@@ -185,6 +193,7 @@ Daher kann ein Indikator nicht allein im Kanal vorkommen. Er muss Teil eines and
 * `indicator.maintenance` - zeigt Systemwarnungen/-fehler, Alarme, Servicemeldungen, leeren Akku oder ähnliches an
 * `indicator.maintenance.lowbat`
 * `indicator.maintenance.unreach`
+* `indicator.maintenance.filter` - der Filter des Gerätes muss gewechselt werden
 * `indicator.maintenance.alarm`
 * `indicator.lowbat` - wahr, wenn der Akku schwach ist
 * `indicator.alarm` - entspricht indicator.maintenance.alarm
@@ -192,6 +201,7 @@ Daher kann ein Indikator nicht allein im Kanal vorkommen. Er muss Teil eines and
 * `indicator.alarm.flood` - Überschwemmung erkannt
 * `indicator.alarm.secure` - Tür oder Fenster ist geöffnet
 * `indicator.alarm.health` - Gesundheitsproblem
+* `indicator.alarm.muted` - der Alarm des Gerätes ist gerade stummgeschaltet
 
 ### Stufen (Zahlen, Lesen/Schreiben)
 Mit **Levels** können Sie einen Zahlenwert steuern oder festlegen.
@@ -224,6 +234,8 @@ Mit **Levels** können Sie einen Zahlenwert steuern oder festlegen.
 * `level.dimmer` - Die Helligkeit ist ebenfalls geringer.
 * `level.blind` - Jalousieposition festlegen (max = vollständig geöffnet, min = vollständig geschlossen)
 * `level.temperature` - gewünschte Temperatur einstellen
+* `level.temperature.heating` - gewünschte Temperatur für das Heizen, für Geräte mit getrenntem Heiz- und Kühlsollwert
+* `level.temperature.cooling` - gewünschte Temperatur für das Kühlen, für Geräte mit getrenntem Heiz- und Kühlsollwert
 * `level.valve` - Sollwert für die Ventilposition
 * `level.color.red`
 * `level.color.green`
@@ -244,7 +256,8 @@ Mit **Levels** können Sie einen Zahlenwert steuern oder festlegen.
 * `level.volume.group` - (`min=0, max=100`) - Lautstärke für die Gerätegruppe
 * `level.curtain` - legt die Vorhangposition fest
 * `level.tilt` - Legt die Neigungsposition der Jalousien fest (max = vollständig geöffnet, min = vollständig geschlossen)
-* `level.speed` - Geschwindigkeit, z. B. Lüfter, Ventilator, ..
+* `level.speed` - Geschwindigkeit, z. B. Lüfter, Ventilator, .. Wird auch als stufenlose Lüfterdrehzahl in % einer Klimaanlage, eines Ventilators oder eines Luftreinigers verwendet, deren gestuftes Gegenstück `level.mode.fan` ist
+* `level.pump` - Sollwert für Drehzahl oder Durchfluss einer Pumpe (Einheit: %)
 
 ### Schalter (Boolesche Werte, Lese-/Schreibzugriff)
 Der Schalter steuert ein boolesches Gerät (`true = ON, false = OFF`)
@@ -268,12 +281,16 @@ Der Schalter steuert ein boolesches Gerät (`true = ON, false = OFF`)
 * `switch.mode.moonlight` - Mondlichtmodus ein-/ausschalten
 * `switch.mode.color` - Farbmodus ein/aus
 * `switch.gate` - schließt (false) oder öffnet (true) das Tor
+* `switch.pump` - Ein/Aus einer Pumpe. Eine eigene Rolle, weil eine Pumpe sonst keinen verpflichtenden Zustand hat und nicht von einer Steckdose zu unterscheiden wäre
 
 ### Klimaanlage oder Thermostat
 * `level.mode.fan` - `AUTO, HIGH, LOW, MEDIUM, QUIET, TURBO`
 * `level.mode.swing` - `AUTO, HORIZONTAL, STATIONARY, VERTICAL`
 * `level.mode.airconditioner` - Klimaanlage: `AUTO, COOL, DRY, ECO, FAN_ONLY, HEAT, OFF`, Heizungsthermostat: `AUTO, MANUAL, VACATION`,
 * `level.mode.thermostat` - Thermostat: `AUTO, MANUAL, VACATION`,
+* `level.mode.airflow` - Richtung des Luftstroms: `FORWARD, REVERSE`
+* `switch.mode.swing` - boolesche Variante von `level.mode.swing` für Geräte, die das Schwenken nur ein- und ausschalten können
+* `value.mode.thermostat` - was das Gerät tatsächlich tut, nur lesbar: `OFF, HEAT, COOL`. Das nur lesbare Gegenstück zu `level.mode.thermostat`
 * `value.mode.airconditioner` - aktueller Gerätestatus: `IDLE`, `HEAT`, `COOL` (0,1,2 in Apple Home)
 
 Zusätzlich zu diesen Staaten sind normalerweise die `level.temperature` und `switch.power` erforderlich, um die Klimaanlage zu kartieren.

--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -56,6 +56,7 @@ If no detailed matching role can be found or the use case is not specific then y
 * `sensor.alarm`          - some common alarm
 * `sensor.alarm.flood`    - water leakage
 * `sensor.alarm.fire`     - fire sensor
+* `sensor.alarm.co`       - carbon monoxide detected
 * `sensor.alarm.secure`   - door opened, window opened or motion detected during alarm is ON.
 * `sensor.alarm.power`    - No power (`voltage = 0`)
 * `sensor.light`          - feedback from the lamp, that it is ON
@@ -118,12 +119,18 @@ Button events triggering onChange on an adapter should be confirmed with ACK = T
 * `value.rn`              - Radon (unit: Bq/m³)
 * `value.tvoc`            - Total volatile organic compounds (unit: µg/m³ or ppb)
 * `value.airquality`      - Air quality index (AQI)
+* `value.so2`             - Sulphur dioxide (unit: µg/m³ or ppm)
+* `value.co.level`, `value.co2.level`, `value.no2.level`, `value.o3.level`, `value.ch2o.level`, `value.pm1.level`, `value.pm25.level`, `value.pm10.level`, `value.rn.level`, `value.tvoc.level`, `value.so2.level` - qualitative level of the concentration of the same name (`common.states={"0": "UNKNOWN", "1": "LOW", "2": "MEDIUM", "3": "HIGH", "4": "CRITICAL"}`)
 * `value.brightness`      - luminance level (unit: lux)
 * `value.min`
 * `value.max`
 * `value.default`
 * `value.battery`         - battery level
 * `value.valve`           - valve level
+* `value.filter`          - remaining condition of a filter (unit: %)
+* `value.filter.carbon`   - remaining condition of an activated carbon filter (unit: %)
+* `value.flow`            - flow rate of a liquid or a gas (unit: m³/h)
+* `value.rssi`            - received signal strength of a radio device (unit: dBm)
 * `value.time`            - getTime() of Date() object
 * `value.timer`           - duration in s (r/o equivalent to `level.timer`)
 * `value.interval`    (common.unit='sec') - Interval in seconds (can be 0.1 or less)
@@ -153,7 +160,7 @@ Button events triggering onChange on an adapter should be confirmed with ACK = T
 * `value.tilt`            - actual tilt position (`max = fully open, min = fully closed`)
 * `value.lock`            - actual position of lock
 * `value.speed`           - wind speed
-* `value.pressure`        - (unit: mbar)
+* `value.pressure`        - (unit: mbar, `hPa` is the same value and is accepted too)
 * `value.distance`
 * `value.distance.visibility`
 * `value.severity`        - some severity (states can be provided), Higher is more important
@@ -174,6 +181,7 @@ So the indicator may not be alone in the channel. It must be some other main sta
 
 * `indicator`
 * `indicator.working`     - indicates that the target system is executing something, like blinds or lock opening.
+* `indicator.working.test` - a self test of the device is in progress
 * `indicator.reachable`   - If a device is online
 * `indicator.connected`   - used only for instances. Use `indicator.reachable` for devices
 * `indicator.direction`   - `true` - up/open, `false` - down/close. Use better `value.direction`
@@ -181,6 +189,7 @@ So the indicator may not be alone in the channel. It must be some other main sta
 * `indicator.maintenance` - indicates system warnings/errors, alarms, service messages, battery empty or stuff like that
 * `indicator.maintenance.lowbat`
 * `indicator.maintenance.unreach`
+* `indicator.maintenance.filter` - the filter of the device has to be changed
 * `indicator.maintenance.alarm`
 * `indicator.lowbat`      - true if low battery
 * `indicator.alarm`       - same as indicator.maintenance.alarm
@@ -188,6 +197,7 @@ So the indicator may not be alone in the channel. It must be some other main sta
 * `indicator.alarm.flood` - flood detected
 * `indicator.alarm.secure` - door or window is opened
 * `indicator.alarm.health` - health problem
+* `indicator.alarm.muted` - the alarm of the device is currently muted
 
 ### Levels (numbers, read-write)
 With **levels**, you can control or set some number value.
@@ -220,6 +230,8 @@ With **levels**, you can control or set some number value.
 * `level.dimmer`          - brightness is dimmer too
 * `level.blind`           - set blind position (max = fully opened, min = fully closed)
 * `level.temperature`     - set desired temperature
+* `level.temperature.heating` - desired temperature for heating, for devices that hold a heating and a cooling setpoint at once
+* `level.temperature.cooling` - desired temperature for cooling, for devices that hold a heating and a cooling setpoint at once
 * `level.valve`           - set point for valve position
 * `level.color.red`
 * `level.color.green`
@@ -240,7 +252,8 @@ With **levels**, you can control or set some number value.
 * `level.volume.group`   - (`min=0, max=100`) - sound volume, for the group of devices
 * `level.curtain`        - set the curtain position
 * `level.tilt`           - set the tilt position of blinds (max = fully opened, min = fully closed)
-* `level.speed`          - speed eg. fan, ventilator, ..
+* `level.speed`          - speed eg. fan, ventilator, .. Also used as the continuous fan speed in % of an air conditioner, fan or air purifier, where the stepped counterpart is `level.mode.fan`
+* `level.pump`           - speed or flow setpoint of a pump (unit: %)
 
 ### Switches (booleans, read-write)
 Switch controls a boolean device (`true = ON, false = OFF`)
@@ -264,12 +277,16 @@ Switch controls a boolean device (`true = ON, false = OFF`)
 * `switch.mode.moonlight` - moon light mode on/off
 * `switch.mode.color`     - color mode on/off
 * `switch.gate`           - closes(false) or opens(true) the gate
+* `switch.pump`           - on/off of a pump. A dedicated role, because a pump has no other mandatory state and could not be told apart from a socket otherwise
 
 ### Air condition or thermostat
 * `level.mode.fan`        - `AUTO, HIGH, LOW, MEDIUM, QUIET, TURBO`
 * `level.mode.swing`      - `AUTO, HORIZONTAL, STATIONARY, VERTICAL`
 * `level.mode.airconditioner` - air conditioner: `AUTO, COOL, DRY, ECO, FAN_ONLY, HEAT, OFF`, heating thermostat: `AUTO, MANUAL, VACATION`, 
 * `level.mode.thermostat` - thermostat: `AUTO, MANUAL, VACATION`,
+* `level.mode.airflow`    - airflow direction: `FORWARD, REVERSE`
+* `switch.mode.swing`     - boolean variant of `level.mode.swing` for devices that can only switch the swing on and off
+* `value.mode.thermostat` - what the device is actually doing, read-only: `OFF, HEAT, COOL`. The read-only counterpart of `level.mode.thermostat`
 * `value.mode.airconditioner` - current device state: `IDLE`, `HEAT, `COOL`  (0,1,2 in apple home) 
  Additionally to these states normally the `level.temperature` and `switch.power` required to map the air conditioner.
 


### PR DESCRIPTION
Follow-up to #643. These roles are already implemented in `@iobroker/type-detector` and had no entry here yet — collected while adding the Matter device types over the last set of PRs there ([type-detector #280, #281, #283–#293](https://github.com/ioBroker/ioBroker.type-detector/pulls)).

Both `docs/en` and `docs/de` are updated, with proper German descriptions rather than copied English. Every role is placed in the section where its siblings already live.

## Roles added

**Air quality** — completes what #643 started
- `value.so2` — sulphur dioxide. Not a Matter cluster, but real sensors exist and Home Assistant has a matching class.
- `value.co.level`, `value.co2.level`, `value.no2.level`, `value.o3.level`, `value.ch2o.level`, `value.pm1.level`, `value.pm25.level`, `value.pm10.level`, `value.rn.level`, `value.tvoc.level`, `value.so2.level` — the qualitative level the Matter concentration-measurement clusters report next to the measured value (`UNKNOWN / LOW / MEDIUM / HIGH / CRITICAL`). Documented as one line, since the pattern is identical for every pollutant.

**Climate**
- `level.temperature.heating`, `level.temperature.cooling` — a Matter thermostat holds both setpoints at once in Auto mode; with only `level.temperature` one of the two values is lost.
- `level.mode.airflow` — `FORWARD, REVERSE`.
- `switch.mode.swing` — the boolean variant of `level.mode.swing`. Already used by the detector's air conditioner type for years, never documented.
- `value.mode.thermostat` — read-only counterpart of `level.mode.thermostat`, the same relation the existing `value.mode.airconditioner` has to `level.mode.airconditioner`.

**Air purifier**
- `value.filter`, `value.filter.carbon` — remaining filter condition; a purifier may carry two filters.
- `indicator.maintenance.filter` — the filter has to be changed.

**Pump**
- `switch.pump`, `level.pump` — the pump gets a role of its own because every other state of the type is optional, so keying detection on `switch.power` would classify every socket as a pump.

**Alarms**
- `sensor.alarm.co` — carbon monoxide, next to the existing `sensor.alarm.fire`. Matter's SmokeCoAlarm can sense smoke, CO, or both.
- `indicator.alarm.muted` — the alarm is currently muted.
- `indicator.working.test` — a self test is running. Deliberately **not** `indicator.working`, which already means "the device is working" and is a shared state of most device types; the two would have collided.

**Sensors**
- `value.flow` — m³/h.
- `value.rssi` — dBm.

## Clarifications to existing roles

- `value.pressure` — noted that `hPa` is accepted as well. It is numerically the same as `mbar`, and devices use both, so fixing one spelling would mislabel half of them.
- `level.speed` — noted that this is also the continuous fan speed of an air conditioner, fan or air purifier, whose stepped counterpart is `level.mode.fan`. No new role: the detector originally introduced a separate `level.fan` for this, and it is being changed to reuse `level.speed` instead, since the existing role already covers exactly this meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)