### PR TITLE
Add the state role level.timer.off

### DIFF
--- a/docs/de/dev/stateroles.md
+++ b/docs/de/dev/stateroles.md
@@ -251,6 +251,7 @@ Mit **Levels** können Sie einen Zahlenwert steuern oder festlegen.
 * `level.effect` - Effekt, üblicherweise für Lichter. Sollte eine Liste möglicher Effekte in `common.states` enthalten. (`common.type=string`).
 * `level.timer`
 * `level.timer.sleep` – Schlaftimer. 0 – aus, oder in Minuten.
+* `level.timer.off` - Zeit in Sekunden, nach der sich das Gerät wieder ausschaltet, z. B. die Einschaltdauer einer Lampe oder einer Steckdose
 * ...
 * `level.volume` - (`min=0, max=100`) - Lautstärke, wobei min und max unterschiedlich sein können. min < max
 * `level.volume.group` - (`min=0, max=100`) - Lautstärke für die Gerätegruppe

--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -247,6 +247,7 @@ With **levels**, you can control or set some number value.
 * `level.effect`          - effect, usually for lights. Should have list of possible effects in `common.states`. (`common.type=string`).
 * `level.timer`
 * `level.timer.sleep`    - sleep timer. 0 - off, or in minutes
+* `level.timer.off`      - time in seconds after which the device switches itself off again, e.g. the on-time of a lamp or a socket
 * ...
 * `level.volume`         - (`min=0, max=100`) - sound volume, but min, max can differ. min < max
 * `level.volume.group`   - (`min=0, max=100`) - sound volume, for the group of devices


### PR DESCRIPTION
Follow-up to #676, which is already merged.

`level.timer.off` is the on-time of a lamp or a socket in seconds — Homematic exposes it and Matter has the `onWithTimedOff` command for the same purpose. It belongs to the `level.timer` family, next to the existing `level.timer.sleep`.

It is used by [ioBroker.type-detector#297](https://github.com/ioBroker/ioBroker.type-detector/pull/297), which was opened after #676 had already gone out, so the role missed that batch. Spotted in review there.

Both `docs/en` and `docs/de`.