### PR TITLE
Add the state roles for the robotic vacuum and the gate contacts

### DIFF
--- a/docs/de/dev/stateroles.md
+++ b/docs/de/dev/stateroles.md
@@ -304,6 +304,10 @@ TODO: Über Ionisation und Oszillation nachdenken.
 * `value.waste` - Füllstand des Abfallbehälters (0-100%). (0% - leer, 100% - voll)
 * `indicator.maintenance.waste` - Der Papierkorb ist ein Idiot.
 * `value.state` - `HOME, CLEANING, PAUSE` und so weiter.
+* `level.mode.vacuum` - Betriebsart eines Saugroboters: `IDLE, CLEANING, MAPPING` sowie herstellereigene Modi. Die Reinigungsstärke ist `level.mode.cleanup`
+* `button.home` - schickt das Gerät zurück zur Ladestation
+* `value.progress` - Fortschritt des laufenden Auftrags (Einheit: %)
+* `value.vacuum.phase` - aktuelle Phase, die das Gerät meldet (`common.type=string`)
 
 Zusätzlich zu diesen Zuständen ist normalerweise `switch.power` erforderlich, um den Staubsauger zu lokalisieren. `switch.power` funktioniert in diesem Fall wie folgt: `true` – Reinigen, `false` – Zurück zum Startpunkt.
 Optional `value.battery` und
@@ -313,6 +317,8 @@ Optional `value.battery` und
 * `value.position` - Position des Tores in Prozent (100 % geöffnet, 0 % geschlossen)
 * `value.gate` - entspricht `value.position`
 * `button.stop` - Stoppt die Bewegung des Tores
+* `indicator.opened` - Endkontakt: das Tor ist vollständig geöffnet
+* `indicator.closed` - Endkontakt: das Tor ist vollständig geschlossen. Beide Kontakte gibt es getrennt, weil ein Tor auch zwischen vollständig geöffnet und vollständig geschlossen stehen kann
 
 ### Medien
 Besondere Rollen für Medienschaffende

--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -299,6 +299,10 @@ TODO: Think about ionization` and oscillation.
 * `value.waste`           - 0-100% waste bin level. (0% - empty, 100% - full)
 * `indicator.maintenance.waste` - Waste bin is fool.
 * `value.state`           - `HOME, CLEANING, PAUSE` and so on.
+* `level.mode.vacuum`     - run mode of a robotic vacuum: `IDLE, CLEANING, MAPPING` and vendor modes. The cleaning intensity is `level.mode.cleanup`
+* `button.home`           - send the device back to its dock
+* `value.progress`        - progress of the running job (unit: %)
+* `value.vacuum.phase`    - current phase reported by the device (`common.type=string`)
 
 Additionally, to these states normally the `switch.power` required to map the vacuum cleaner. `switch.power` in this case works as: `true` - clean, `false` - back to home.
 Optionally `value.battery` and  
@@ -308,6 +312,8 @@ Optionally `value.battery` and
 * `value.position`        - position of the gate in percent (100% opened, 0% - closed)
 * `value.gate`            - same as `value.position`
 * `button.stop`           - stop the motion of the gate
+* `indicator.opened`      - end contact: the gate is fully opened
+* `indicator.closed`      - end contact: the gate is fully closed. Both contacts exist separately, because a gate can also stand between fully opened and fully closed
 
 ### Media
 Special roles for media players


### PR DESCRIPTION
Second batch of roles collected from the device type work in `@iobroker/type-detector`. All are implemented there and had no entry here yet. Both `docs/en` and `docs/de`, each placed in the section where its siblings already live.

## Robotic vacuum — [type-detector#306](https://github.com/ioBroker/ioBroker.type-detector/pull/306), issue #278

Added to the *Vacuum cleaner* section:

- `level.mode.vacuum` — the run mode: `IDLE, CLEANING, MAPPING` plus vendor modes. Deliberately separate from the existing `level.mode.cleanup`, which is the cleaning **intensity**; Matter exposes the two as different clusters (`RvcRunMode` vs `RvcCleanMode`).
- `button.home` — send the device back to its dock. Home Assistant has a standard `return_to_home` service that could not be wired without it.
- `value.progress` — progress of the running job, %.
- `value.vacuum.phase` — the phase text the device reports, a string.

## Gate contacts — [type-detector#305](https://github.com/ioBroker/ioBroker.type-detector/pull/305), issue #99

Added to the *Gate* section:

- `indicator.opened` — end contact, fully opened.
- `indicator.closed` — end contact, fully closed.

Two roles rather than one boolean, because a gate can also stand **between** fully opened and fully closed, and a single state cannot express that.

## Still pending from the previous round

#678 adds `level.timer.off` (the on-time of a lamp or a socket) and is still open. That role is already merged in the type detector, so it is the one gap left. Happy to fold it into this PR instead if that is easier to review.