### PR TITLE
Document the state roles that the type detector still uses undocumented

### DIFF
--- a/docs/de/dev/stateroles.md
+++ b/docs/de/dev/stateroles.md
@@ -79,6 +79,7 @@ Benutzeroberflächen sollten den Wert dieses Zustands weder auslesen noch erwart
 * `button`
 * `button.long`
 * `button.stop` - z.B. rollo stop,
+* `button.stop.blind` - stoppt die Bewegung einer Jalousie (Gerätetypen `blind`, `blindButtons`)
 * `button.stop.tilt`
 * `button.start`
 * `button.resume`
@@ -103,7 +104,7 @@ Benutzeroberflächen sollten den Wert dieses Zustands weder auslesen noch erwart
 ### Werte (Zahlen, schreibgeschützt)
 `common.type=number, common.write=false`
 
-* `Wert`
+* `value`
 * `value.window` (`common.states={"0": "CLOSED", "1": "TILTED", "2": "OPEN"}`) Es ist wichtig, dass (`CLOSED/TILTED/OPEN`) vorhanden ist. Die Werte können unterschiedlich sein.
 * `value.temperature` (`common.unit='°C' or '°F' or 'K'`)
 * `value.temperature.dewpoint` (`common.unit='°C' or '°F')
@@ -125,6 +126,9 @@ Benutzeroberflächen sollten den Wert dieses Zustands weder auslesen noch erwart
 * `value.so2`             - Schwefeldioxid (Einheit: µg/m³ oder ppm)
 * `value.co.level`, `value.co2.level`, `value.no2.level`, `value.o3.level`, `value.ch2o.level`, `value.pm1.level`, `value.pm25.level`, `value.pm10.level`, `value.rn.level`, `value.tvoc.level`, `value.so2.level` - qualitative Stufe der gleichnamigen Konzentration (`common.states={"0": "UNKNOWN", "1": "LOW", "2": "MEDIUM", "3": "HIGH", "4": "CRITICAL"}`)
 * `value.brightness` - Leuchtdichtewert (Einheit: Lux)
+* `value.dimmer` - aktuelle Helligkeit in % (Gerätetyp `dimmer`)
+* `value.volume` - aktuelle Lautstärke in % (Gerätetypen `media`, `volume`)
+* `value.volume.group` - aktuelle Lautstärke einer Gerätegruppe in % (Gerätetyp `volumeGroup`)
 * `value.min`
 * `value.max`
 * `value.default`
@@ -270,6 +274,7 @@ Der Schalter steuert ein boolesches Gerät (`true = ON, false = OFF`)
 * `switch.lock.door` - Türschloss
 * `switch.lock.window` - Fenstersperre
 * `switch.mode.boost` - Start/Stopp des Boost-Modus des Thermostats
+* `switch.boost` - Start/Stopp des Boost-Modus. Ältere Variante von `switch.mode.boost`, wird weiterhin akzeptiert (Gerätetyp `airCondition`)
 * `switch.mode.party` - Startet/Stoppt den Partymodus des Thermostats
 * `switch.power` - Ein-/Ausschalten von Strom, Thermostat oder Klimaanlage
 * `switch.light`
@@ -305,6 +310,12 @@ TODO: Über Ionisation und Oszillation nachdenken.
 * `value.waste` - Füllstand des Abfallbehälters (0-100%). (0% - leer, 100% - voll)
 * `indicator.maintenance.waste` - Der Papierkorb ist ein Idiot.
 * `value.state` - `HOME, CLEANING, PAUSE` und so weiter.
+* `vacuum.map.base64` - Karte der gereinigten Fläche als base64 kodiertes Bild (`common.type=string`)
+* `value.usage.filter` - verbleibende Lebensdauer des Filters in %
+* `value.usage.brush` - verbleibende Lebensdauer der Hauptbürste in %
+* `value.usage.brush.side` - verbleibende Lebensdauer der Seitenbürste in %
+* `value.usage.sensors` - verbleibende Zeit in %, bis die Sensoren gereinigt werden müssen
+* `indicator.maintenance.water` - der Wassertank muss gefüllt werden
 * `level.mode.vacuum` - Betriebsart eines Saugroboters: `IDLE, CLEANING, MAPPING` sowie herstellereigene Modi. Die Reinigungsstärke ist `level.mode.cleanup`
 * `button.home` - schickt das Gerät zurück zur Ladestation
 * `value.progress` - Fortschritt des laufenden Auftrags (Einheit: %)
@@ -353,6 +364,8 @@ Besondere Rollen für Medienschaffende
 * `media.elapsed` - (`common.type=number`) Sekunden
 * `media.broadcastDate` - (`common.type=string`) Sendedatum
 * `media.mute` - (`common.type=boolean`) true bedeutet stummgeschaltet
+* `media.player.name` - Name des Players (`common.type=string`)
+* `media.player.type` - Typ des Players, z. B. das Modell (`common.type=string`)
 * `media.season` - (`common.type=string`) Saisonnummer (wichtig: Der Typ ist tatsächlich "string", um das Fehlen einer Saison mit "") angeben zu können.
 * `media.episode` - (`common.type=string`) Episodennummer (wichtig: Der Typ ist tatsächlich "string", um das Fehlen einer Episode mit "") anzeigen zu können.
 * `media.mute.group` - (`common.type=boolean`) Stummschaltung einer Gruppe von Geräten
@@ -420,6 +433,8 @@ Besondere Rollen für Medienschaffende
 ### Wetter
 * `Datum` - tatsächliches Datum oder Datum der letzten gelesenen Informationen
 * `date.forecast.1` - Datum von morgen
+* `date.forecast.0` - Datum von heute
+* `dayofweek.forecast.0` - Wochentag von heute als Text
 * `date.sunrise` - Sonnenaufgang für heute
 * `date.sunset` - Sonnenuntergang für heute
 * `dayofweek` - Wochentag als Text
@@ -432,6 +447,11 @@ Besondere Rollen für Medienschaffende
 * `value.direction.wind.forecast.1` - Windrichtungsvorhersage für morgen in Grad
 * `value.humidity` - tatsächliche oder durchschnittliche Luftfeuchtigkeit
 * `value.humidity.max` - tatsächliche Luftfeuchtigkeit
+* `value.humidity.forecast.0` - Vorhersage der Luftfeuchtigkeit für heute
+* `value.temperature.forecast.0` - Vorhersage der Temperatur für heute
+* `value.temperature.feelslike.forecast.0` - Vorhersage der gefühlten Temperatur für heute
+* `value.temperature.windchill.forecast.0` - Vorhersage des Windchill für heute
+* `value.pressure.tendency` - Tendenz des Luftdrucks als Text, z. B. `up`, `down`, `stable` (`common.type=string`)
 * `value.humidity.min` - tatsächliche Luftfeuchtigkeit
 * `value.precipitation` - (`Typ: Zahl, Einheit: mm`) Niederschlag für die letzten 24 Stunden Regen/Schnee (Niederschlag heute für Schnee oder Regen / осадки сегодня снега или дождя)
 * `value.precipitation.chance` - Tatsächliche Niederschlagswahrscheinlichkeit für heute
@@ -477,6 +497,8 @@ Besondere Rollen für Medienschaffende
 * `weather.direction.wind.forecast.0` - Windrichtungsvorhersage für heute als Text
 * `weather.html` - HTML-Objekt mit Wetterbeschreibung
 * `weather.icon` - Aktuelle URL des Status-Symbols
+* `weather.icon.forecast.0` - URL des Status-Symbols der Vorhersage für heute
+* `weather.icon.wind.forecast.0` - URL des Wind-Symbols der Vorhersage für heute
 * `weather.icon.forecast.1` - Symbol für morgen
 * `weather.icon.name` - Aktueller Name des Status-Symbols
 * `weather.icon.wind` - Aktuelle URL des Windsymbols
@@ -516,6 +538,19 @@ Besondere Rollen für Medienschaffende
 * `value.health.bpm` - Herzschläge pro Minute
 
 ### Andere
+
+Rollen einer Kamera (Gerätetyp `camera`):
+
+* `link.camera` - URL des Kamerabildes (`common.type=string`)
+* `level.camera.position` - Schwenk-, Neige- und Zoomposition der Kamera
+* `switch.camera.autofocus` - Autofokus ein/aus
+* `switch.camera.autowhitebalance` - automatischer Weißabgleich ein/aus
+* `switch.camera.brightness` - Helligkeitskorrektur ein/aus
+* `switch.camera.nightmode` - Nachtmodus ein/aus
+
+Rolle eines Bildes (Gerätetyp `image`):
+
+* `icon` - URL eines Bildes oder eines Symbols (`common.type=string`)
 * `url`
 * `url.icon` - Symbol (zusätzlich kann jedes Objekt ein `common.icon` haben)
 * `url.cam` - URL der Webcam

--- a/docs/en/dev/stateroles.md
+++ b/docs/en/dev/stateroles.md
@@ -76,6 +76,7 @@ Button events triggering onChange on an adapter should be confirmed with ACK = T
 * `button`
 * `button.long`
 * `button.stop`           - e.g. rollo stop,
+* `button.stop.blind`     - stop the motion of a blind (device types `blind`, `blindButtons`)
 * `button.stop.tilt`
 * `button.start`
 * `button.resume`
@@ -122,6 +123,9 @@ Button events triggering onChange on an adapter should be confirmed with ACK = T
 * `value.so2`             - Sulphur dioxide (unit: µg/m³ or ppm)
 * `value.co.level`, `value.co2.level`, `value.no2.level`, `value.o3.level`, `value.ch2o.level`, `value.pm1.level`, `value.pm25.level`, `value.pm10.level`, `value.rn.level`, `value.tvoc.level`, `value.so2.level` - qualitative level of the concentration of the same name (`common.states={"0": "UNKNOWN", "1": "LOW", "2": "MEDIUM", "3": "HIGH", "4": "CRITICAL"}`)
 * `value.brightness`      - luminance level (unit: lux)
+* `value.dimmer`          - actual dimming level in % (device type `dimmer`)
+* `value.volume`          - actual sound volume in % (device types `media`, `volume`)
+* `value.volume.group`    - actual sound volume of a group of devices in % (device type `volumeGroup`)
 * `value.min`
 * `value.max`
 * `value.default`
@@ -266,6 +270,7 @@ Switch controls a boolean device (`true = ON, false = OFF`)
 * `switch.lock.door`      - door lock
 * `switch.lock.window`    - window lock
 * `switch.mode.boost`     - start/stop boost mode of thermostat
+* `switch.boost`          - start/stop boost mode. Older variant of `switch.mode.boost`, still accepted (device type `airCondition`)
 * `switch.mode.party`     - start/stop party mode of thermostat
 * `switch.power`          - on/off power, thermostat or air conditioner
 * `switch.light`
@@ -300,6 +305,12 @@ TODO: Think about ionization` and oscillation.
 * `value.waste`           - 0-100% waste bin level. (0% - empty, 100% - full)
 * `indicator.maintenance.waste` - Waste bin is fool.
 * `value.state`           - `HOME, CLEANING, PAUSE` and so on.
+* `vacuum.map.base64`     - map of the cleaned area as a base64 encoded image (`common.type=string`)
+* `value.usage.filter`    - remaining life of the filter in %
+* `value.usage.brush`     - remaining life of the main brush in %
+* `value.usage.brush.side` - remaining life of the side brush in %
+* `value.usage.sensors`   - remaining time in % until the sensors have to be cleaned
+* `indicator.maintenance.water` - the water tank has to be filled
 * `level.mode.vacuum`     - run mode of a robotic vacuum: `IDLE, CLEANING, MAPPING` and vendor modes. The cleaning intensity is `level.mode.cleanup`
 * `button.home`           - send the device back to its dock
 * `value.progress`        - progress of the running job (unit: %)
@@ -348,6 +359,8 @@ Special roles for media players
 * `media.elapsed`         - (`common.type=number`) seconds
 * `media.broadcastDate`   - (`common.type=string`) Broadcast date
 * `media.mute`            - (`common.type=boolean`) true is muted
+* `media.player.name`     - name of the player (`common.type=string`)
+* `media.player.type`     - type of the player, e.g. the model (`common.type=string`)
 * `media.season`          - (`common.type=string`) season number (important the type is really "string" to be able to indicate absence of season with "")
 * `media.episode`         - (`common.type=string`) episode number (important the type is really "string" to be able to indicate absence of episode with "")
 * `media.mute.group`      - (`common.type=boolean`) mute of a group of devices
@@ -415,6 +428,8 @@ Special roles for media players
 ### Weather
 * `date`                        - actual date or date of last-read information
 * `date.forecast.1`                 - tomorrow date
+* `date.forecast.0`                 - today date
+* `dayofweek.forecast.0`            - day of week of today as text
 * `date.sunrise`                - Sunrise for today
 * `date.sunset`                 - Sunset for today
 * `dayofweek`                   - day of week as text
@@ -427,6 +442,11 @@ Special roles for media players
 * `value.direction.wind.forecast.1` - wind direction forecast for tomorrow in degrees
 * `value.humidity`              - actual or average humidity
 * `value.humidity.max`          - actual humidity
+* `value.humidity.forecast.0`   - humidity forecast for today
+* `value.temperature.forecast.0` - temperature forecast for today
+* `value.temperature.feelslike.forecast.0` - felt temperature forecast for today
+* `value.temperature.windchill.forecast.0` - wind chill forecast for today
+* `value.pressure.tendency`     - tendency of the air pressure as text, e.g. `up`, `down`, `stable` (`common.type=string`)
 * `value.humidity.min`          - actual humidity
 * `value.precipitation`         - (`type: number, unit: mm`) precipitation for last 24 hours rain/snow (Niederschlag heute für Schnee oder Regen / осадки сегодня снега или дождя)
 * `value.precipitation.chance`  - Actual precipitation chance for today
@@ -472,6 +492,8 @@ Special roles for media players
 * `weather.direction.wind.forecast.0` - wind direction forecast for today as text
 * `weather.html`                - HTML object with weather description
 * `weather.icon`                - Actual state icon URL for now
+* `weather.icon.forecast.0`     - state icon URL of the forecast for today
+* `weather.icon.wind.forecast.0` - wind icon URL of the forecast for today
 * `weather.icon.forecast.1`         - tomorrow icon
 * `weather.icon.name`           - Actual state icon name for now
 * `weather.icon.wind`           - Actual wind icon URL for now
@@ -511,6 +533,19 @@ Special roles for media players
 * `value.health.bpm`      - heart beats per minute
 
 ### Others
+
+Roles of a camera (device type `camera`):
+
+* `link.camera`           - URL of the camera image (`common.type=string`)
+* `level.camera.position` - pan, tilt and zoom position of the camera
+* `switch.camera.autofocus` - autofocus on/off
+* `switch.camera.autowhitebalance` - automatic white balance on/off
+* `switch.camera.brightness` - brightness correction on/off
+* `switch.camera.nightmode` - night mode on/off
+
+Role of an image (device type `image`):
+
+* `icon`                  - URL of an image or an icon (`common.type=string`)
 * `url`
 * `url.icon`               - icon (additionally every object can have `common.icon`)
 * `url.cam`                - web camera url


### PR DESCRIPTION
Not new roles this time — these are **long-standing** ones that `@iobroker/type-detector` already uses to create states and that had no entry here.

## How they were found

Mechanically, not by memory: every `defaultRole` in the detector's patterns was extracted and diffed against this file. Of the **208** roles it uses, **29** were undocumented in English and 30 in German. After this PR both are at zero.

`defaultRole` is what `ioBroker.devices` and `ioBroker.matter` write when they *create* a state, so an undocumented one means an adapter author has no way to look up what to emit.

Each entry names the device types that use it, so the connection back to the detector is visible from here.

## Camera — new short section

There was no camera section at all, though the detector has had a `camera` type for years:

`link.camera`, `level.camera.position`, `switch.camera.autofocus`, `switch.camera.autowhitebalance`, `switch.camera.brightness`, `switch.camera.nightmode`

## Vacuum cleaner

`vacuum.map.base64`, the four `value.usage.*` wear levels (filter, main brush, side brush, sensors) and `indicator.maintenance.water`.

## Weather

The *today* forecast variants that were missing next to the already documented *tomorrow* ones: `date.forecast.0`, `dayofweek.forecast.0`, `value.humidity.forecast.0`, `value.temperature.forecast.0`, `value.temperature.feelslike.forecast.0`, `value.temperature.windchill.forecast.0`, `weather.icon.forecast.0`, `weather.icon.wind.forecast.0`, plus `value.pressure.tendency`.

## Media and the rest

`media.player.name`, `media.player.type`, `value.volume`, `value.volume.group`, `value.dimmer`, `button.stop.blind`, `icon`, and `switch.boost` — documented as the older variant of `switch.mode.boost`, since the detector still accepts both.

## One fix in the German file

The role `value` had been translated to `Wert`. A role is an identifier rather than prose, so it is restored to `value` — otherwise it is the only role in the file that cannot be copied into an adapter.

## Related

One role was **not** added here on purpose: `weatherCurrent`'s wind speed carried `value.speed.wind$`, with a regular expression anchor accidentally copied into the role string. That is a defect in the detector and is fixed in [ioBroker.type-detector#309](https://github.com/ioBroker/ioBroker.type-detector/pull/309); the correct role `value.speed.wind` is already documented here.